### PR TITLE
Handle os error 3.

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -64,6 +64,7 @@ pub fn remove_dir(path: &Path) -> io::Result<bool> {
     match fs::remove_dir(path) {
         Err(err) => match err.raw_os_error().unwrap() as u32 {
             winerror::ERROR_FILE_NOT_FOUND => Ok(true),
+            winerror::ERROR_PATH_NOT_FOUND => Ok(true),
             winerror::ERROR_DIR_NOT_EMPTY => Ok(false),
             _ => Err(err),
         },


### PR DESCRIPTION
When using this tool, I sometimes experience os error 3 return codes when the folder does not exist and this operation tries to run.

Adding ERROR_PATH_NOT_FOUND as a handled error should resolve this issue.